### PR TITLE
feat: better sticky options

### DIFF
--- a/Examples/UIKitExample/UIKitExample/Modals/MenuModal.swift
+++ b/Examples/UIKitExample/UIKitExample/Modals/MenuModal.swift
@@ -95,20 +95,31 @@ class MenuModal: UIViewController, ModalView {
 
         // Actions
         pushBtn .addTarget(self, action: #selector(pushAnotherMenu), for: .touchUpInside)
-        popBtn  .addTarget(self, action: #selector(popModal),        for: .touchUpInside)
-        morphBtn.addTarget(self, action: #selector(openMorph),       for: .touchUpInside)
-        inputBtn.addTarget(self, action: #selector(openInput),       for: .touchUpInside)
-        listBtn .addTarget(self, action: #selector(openList),        for: .touchUpInside)
-        closeBtn.addTarget(self, action: #selector(closeFlow),       for: .touchUpInside)
+        popBtn  .addTarget(self, action: #selector(popModal), for: .touchUpInside)
+        morphBtn.addTarget(self, action: #selector(openMorph), for: .touchUpInside)
+        inputBtn.addTarget(self, action: #selector(openInput), for: .touchUpInside)
+        listBtn .addTarget(self, action: #selector(openList), for: .touchUpInside)
+        closeBtn.addTarget(self, action: #selector(closeFlow), for: .touchUpInside)
     }
 
     // MARK: Navigation
-    @objc private func pushAnotherMenu() { modalVC?.push(MenuModal(), sticky: StickyElements.self) }
-    @objc private func popModal() { modalVC?.pop() }
+    
+    // Morph inner content
     @objc private func openMorph() { modalVC?.replace(with: MorphModal(step: .one)) }
-    @objc private func openInput() { modalVC?.push(InputModal(),   sticky: StickyElements.self) }
-    @objc private func openList() { modalVC?.push(ScrollModal(),  sticky: StickyElements.self) }
+    // Programatically pop a modal
+    @objc private func popModal() { modalVC?.pop() }
+    
+    // Example push - same MenuModal
+    /// It's likely you won't be pushing the same modal content in your real usage
+    /// but for simplicity we'll reuse the same menuModal and we'll inherit the previous stacks sticky elements here to be used during morph
+    @objc private func pushAnotherMenu() { modalVC?.push(MenuModal(), sticky: .inherit) }
+    
+    // Navigate to other views
+    @objc private func openInput() { modalVC?.push(InputModal()) }
     @objc private func closeFlow() { modalVC?.hide() }
+    
+    // Example of pushing with a new StickyElementsContainer view
+    @objc private func openList() { modalVC?.push(ScrollModal(), sticky: .sticky(ScrollStickyElements.self)) }
 
     func preferredHeight(for _: CGFloat) -> CGFloat { 324 }
 }

--- a/Examples/UIKitExample/UIKitExample/Modals/ScrollModal.swift
+++ b/Examples/UIKitExample/UIKitExample/Modals/ScrollModal.swift
@@ -21,7 +21,7 @@ class ScrollModal: UIViewController, ModalView {
         tv.showsVerticalScrollIndicator = false
         tv.textContainerInset = .init(top: 32, left: 20, bottom: 32, right: 20)
         tv.font = .rounded(ofSize: 17, weight: .medium)
-        tv.backgroundColor = .tertiarySystemGroupedBackground
+        tv.backgroundColor = .secondarySystemGroupedBackground
         tv.textColor = .label
         return tv
     }()

--- a/Examples/UIKitExample/UIKitExample/Modals/ScrollStickyElements.swift
+++ b/Examples/UIKitExample/UIKitExample/Modals/ScrollStickyElements.swift
@@ -1,0 +1,50 @@
+//
+//  ScrollStickyElements.swift
+//  UIKitExample
+//
+//  Created by Joseph Smith on 06/07/2025.
+//
+
+import UIKit
+import MorphModalKit
+
+// This is an example of using a different StickyElementsContainer for a push
+// Realistically you'd probably have this gradient view within the ModalView for the ScrollModal
+// This is just showcasing how you could have different sticky elements per stack push
+class ScrollStickyElements: StickyElementsContainer {
+    private let gradientContainer = UIView()
+
+    required init(modalVC: ModalViewController) {
+        super.init(modalVC: modalVC)
+        
+        gradientContainer.translatesAutoresizingMaskIntoConstraints = false
+        gradientContainer.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        addSubview(gradientContainer)
+        NSLayoutConstraint.activate([
+            gradientContainer.topAnchor.constraint(equalTo: topAnchor),
+            gradientContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            gradientContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+            gradientContainer.heightAnchor.constraint(equalToConstant: 40)
+        ])
+    }
+    
+    required init?(coder: NSCoder) { fatalError() }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let gradient = CAGradientLayer()
+        gradient.colors = [
+            UIColor.tertiarySystemGroupedBackground.cgColor,
+            UIColor.tertiarySystemGroupedBackground.withAlphaComponent(0).cgColor
+        ]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        gradient.frame = gradientContainer.bounds
+        gradientContainer.layer.sublayers?.forEach { $0.removeFromSuperlayer() }
+        gradientContainer.layer.insertSublayer(gradient, at: 0)
+    }
+    
+    override func contextDidChange(to newOwner: ModalView, from _: ModalView?, animated: Bool) {
+        // No need to do anything here
+    }
+}

--- a/Examples/UIKitExample/UIKitExample/ViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/ViewController.swift
@@ -70,7 +70,9 @@ class ViewController: UIViewController {
         // options.bottomSpacing = 0
         // options.cornerMask = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         
-        self.presentModal(MenuModal(), options: options, sticky: StickyElements.self)
+        // We pass the elements we want to be sticky through morphs when we present the modal
+        // these can be inherited (default) by future pushes or overwritten
+        self.presentModal(MenuModal(), options: options, sticky: .sticky(StickyElements.self))
     }
 }
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Joseph Smith
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ All presentation APIs live on any `UIViewController` once you import MorphModalK
 presentModal(
   ExampleModal(),
   options: ModalOptions.default,
-  sticky: StickyElementsContainer.Type? = nil,
+  sticky: StickyOption = .none,
   animated: true,
   showsOverlay: true
 )
 ```
 
-- **`sticky`**: supply a subclass of `StickyElementsContainer` to render persistent UI during morph (replace) animations.
+- **`sticky` (optional)**: supply a subclass of `StickyElementsContainer` using `.sticky(MySticky.self)` to render persistent UI which sticks around during morph (replace) animations. Allowing you to have a view which acts as a container of shared elements between replace calls.
 - **`options`**: adjust layout, shadows, animation springs, and more (see Configuration below).
 
 ### Pushing & Popping
@@ -119,10 +119,12 @@ presentModal(
 Within a `ModalView`, you can retrieve the host controller:
 
 ```swift
-modalVC?.push(AnotherModal(), sticky: MySticky.self)
-modalVC?.pop()        // back to previous card
-modalVC?.hide()       // dismiss the entire stack
+modalVC?.push(AnotherModal()) // new modalView added to the stack
+modalVC?.pop() // back to previous card
+modalVC?.hide() // dismiss the entire stack
 ```
+
+When you push a new modal to the stack you can also provide `sticky` param (defaults to `.none`) to either inherit the previous modals sticky elements, provide a new sticky with `.sticky(MySticky.self)` element or set it to `.none`.
 
 ### Replace (Morph)
 

--- a/Sources/MorphModalKit/ModalViewController.swift
+++ b/Sources/MorphModalKit/ModalViewController.swift
@@ -26,6 +26,12 @@ public enum ReplaceAnimation: Equatable {
     case slide(_ points: CGFloat)
 }
 
+public enum StickyOption {
+  case none
+  case inherit
+  case sticky(StickyElementsContainer.Type)
+}
+
 public struct ModalOptions {
     // layout
     public var horizontalInset: CGFloat = 10
@@ -84,7 +90,7 @@ public final class ModalViewController: UIViewController {
     public func present(
         _ modal:ModalView,
         options: ModalOptions = ModalOptions.default,
-        sticky: StickyElementsContainer.Type? = nil,
+        sticky: StickyOption = .none,
         animated:Bool = true,
         showsOverlay:Bool = true,
         completion:(()->Void)? = nil) {
@@ -118,7 +124,7 @@ public final class ModalViewController: UIViewController {
     public func push(
         _ modal:ModalView,
         options: ModalOptions? = nil,
-        sticky: StickyElementsContainer.Type? = nil,
+        sticky: StickyOption = .none,
         animated:Bool = true,
         completion:(()->Void)? = nil)
     {
@@ -130,8 +136,23 @@ public final class ModalViewController: UIViewController {
             view.insertSubview(overlay, at: 0)
             overlay.frame = view.bounds
         }
+        
+        let stickyType: StickyElementsContainer.Type?
+        switch sticky {
+        case .none:
+          stickyType = nil
+        case .sticky(let type):
+          stickyType = type
+        case .inherit:
+          // if there’s a previous container, pull its sticky’s class
+          if let prev = containerStack.last {
+            stickyType = type(of: prev.sticky)
+          } else {
+            stickyType = nil
+          }
+        }
 
-        var c = makeContainer(for: modal, sticky: sticky)
+        var c = makeContainer(for: modal, sticky: stickyType)
         layout(&c)
         c.wrapper.transform = .init(
             translationX: 0,

--- a/Sources/MorphModalKit/UIViewController+MorphModal.swift
+++ b/Sources/MorphModalKit/UIViewController+MorphModal.swift
@@ -19,7 +19,7 @@ public extension UIViewController {
     func presentModal(
         _ root: ModalView,
         options: ModalOptions = ModalOptions.default,
-        sticky: StickyElementsContainer.Type? = nil,
+        sticky: StickyOption = .none,
         animated: Bool = true,
         showsOverlay: Bool = true) {
             let host = ModalViewController()


### PR DESCRIPTION
- Adds StickyOption which is a type of `.sticky(StickyElementsContainer.Type)`, `.inherit` which pulls from the previous modalView in the stack or `.none` (default)
- Updates docs
- Updates examples