### PR TITLE
feat: add overlayTapBehavior option for tap-to-pop dismiss

### DIFF
--- a/Sources/MorphModalKit/ModalViewController.swift
+++ b/Sources/MorphModalKit/ModalViewController.swift
@@ -45,6 +45,11 @@ public enum ModalGlassStyle {
     }
 }
 
+public enum OverlayTapBehavior {
+    case dismissAll
+    case popTop
+}
+
 public struct ModalOptions {
     // layout
     public var horizontalInset: CGFloat = 10
@@ -81,6 +86,7 @@ public struct ModalOptions {
     // behavior
     public var usesSnapshots: Bool = true
     public var usesSnapshotsForMorph: Bool = false
+    public var overlayTapBehavior: OverlayTapBehavior = .dismissAll
 
     // animations
     public var animation: ModalAnimationSettings = .init()
@@ -591,7 +597,10 @@ public final class ModalViewController: UIViewController {
         guard dismissFromOverlayTaps,
               g.state == .ended,
               containerStack.last?.modalView.canDismiss ?? true else { return }
-        hide()
+        switch options.overlayTapBehavior {
+        case .dismissAll: hide()
+        case .popTop:     pop()
+        }
     }
     
     func refreshScrollDismissBinding() {


### PR DESCRIPTION
## Summary

The overlay-tap and swipe-down dismiss paths currently behave differently when more than one modal is on the stack:

- **Swipe-down** invokes `pop()` ([`ModalViewController.swift`, `interactionDidDismiss`](https://github.com/jsmmth/MorphModalKit/blob/main/Sources/MorphModalKit/ModalViewController.swift)) — pops the foreground modal only.
- **Overlay tap** invokes `hide()` ([`onOverlayTap`](https://github.com/jsmmth/MorphModalKit/blob/main/Sources/MorphModalKit/ModalViewController.swift)) — tears down the entire stack.

For apps that push trays from trays (chooser → editor → date picker), the inconsistency is user-visible: swiping down peels one layer, but tapping outside collapses everything. Users reasonably expect tap-outside to mirror swipe-down.

This PR introduces a configurable behavior rather than changing the default:

```swift
public enum OverlayTapBehavior {
    case dismissAll   // current behavior — full stack teardown
    case popTop       // mirror swipe-down — pop the foreground modal only
}

public struct ModalOptions {
    // ...
    public var overlayTapBehavior: OverlayTapBehavior = .dismissAll
}
```

The default is `.dismissAll`, so existing apps are unaffected. Apps that want stack-aware tap dismissal opt in:

```swift
var opts = ModalOptions.default
opts.overlayTapBehavior = .popTop
controller.present(modal, options: opts)
```

`pop()` already handles the "only one modal on the stack" case by delegating to `hide()`, so `.popTop` with a single modal behaves identically to `.dismissAll`.

## Diff

One file, 12 added lines, 1 removed:

- Add `OverlayTapBehavior` enum
- Add `ModalOptions.overlayTapBehavior` property (defaults to `.dismissAll`)
- Switch on it inside `onOverlayTap`

No API removals, no migration needed.